### PR TITLE
Methods and example of how to get schedule block targets and target details from our catalogues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ Thumbs.db
 version.txt
 dump.rdb
 build
+
+# Test results #
+###############
+nosetests.xml

--- a/examples/get_target_descriptions.py
+++ b/examples/get_target_descriptions.py
@@ -29,69 +29,43 @@ def main():
     # Change URL to point to a valid portal node.  Subarray can be 1 to 4.
     # Note: if on_update_callback is set to None, then we cannot use the
     #       KATPortalClient.connect() method (i.e. no websocket access).
-    client = KATPortalClient('http://localhost/api/client',
+    client = KATPortalClient('http://localhost/api/client/1',
                              on_update_callback=None, logger=logger)
 
-    # Get the pointing details of a set of targets from a specified
-    # reference observer location and time.
-    results = yield client.get_target_descriptions(
-        targets='Sun,Jupiter,Moon,Saturn',
+    results = yield client.future_targets('20170123-0017')
+    print results
+
+    # Example output:
+    # [{u'target': u'Moon', u'slew_time': 53.6153013706, u'track_duration': 4.0}]
+
+    client.set_reference_observer_config(
         longitude=10.0,
         latitude=10.0,
         altitude=10.0,
         timestamp=time.time() + 3600)  # one hour in the future
 
+    results = yield client.future_targets_detail('20170123-0017')
     print results
 
     # Example output:
-    # [{u'apparent_radec': [5.4887616314, -0.29992498700000003],
-    #   u'astrometric_radec': [5.4847563805, -0.3010704971],
-    #   u'azel': [4.4004411697, 0.0379281938],
-    #   u'body_type': u'special',
-    #   u'description': u'Sun, special',
-    #   u'galactic': [0.529324994, -0.6162473516],
-    #   u'name': u'Sun',
-    #   u'parallactic_angle': 1.3759373506,
-    #   u'tags': [u'special'],
-    #   u'uvw_basis': [[0.09444946950000001, -0.1716449975, 0.9806208710000001],
-    #    [-0.2942402405, 0.9362039477, 0.1922104296],
-    #    [-0.9510530893, -0.30669229400000003, 0.0379191009]]},
-    #  {u'apparent_radec': [3.5236462803, -0.1338425836],
-    #   u'astrometric_radec': [3.5197356490000002, -0.1323132089],
-    #   u'azel': [1.4582693576999999, -1.2722665070999999],
-    #   u'body_type': u'special',
-    #   u'description': u'Jupiter, special',
-    #   u'galactic': [5.5499747102, 0.9469744139],
-    #   u'name': u'Jupiter',
-    #   u'parallactic_angle': -1.4119492999999999,
-    #   u'tags': [u'special'],
-    #   u'uvw_basis': [[-0.9555055370000001, 0.051833308200000004, -0.2903833274],
-    #    [0.039950485200000004, 0.9981095051000001, 0.0467051874],
-    #    [0.2922552436, 0.0330261103, -0.9557699245000001]]},
-    #  {u'apparent_radec': [6.2454304801, -0.0559296419],
-    #   u'astrometric_radec': [6.2526110484, -0.053966023200000005],
-    #   u'azel': [4.4375019073, 0.8184230924],
-    #   u'body_type': u'special',
-    #   u'description': u'Moon, special',
-    #   u'galactic': [1.5751063885, -1.0855229806],
-    #   u'name': u'Moon',
-    #   u'parallactic_angle': 1.2510601122,
-    #   u'tags': [u'special'],
-    #   u'uvw_basis': [[0.7523615662, -0.1143044787, 0.6487577050000001],
-    #    [-0.0368902681, 0.9759746871, 0.2147382554],
-    #    [-0.6577166425000001, -0.18549365580000002, 0.7300691213]]},
-    #  {u'apparent_radec': [4.610326769, -0.3846675644],
-    #   u'astrometric_radec': [4.6059450635, -0.3845379545],
-    #   u'azel': [4.3407421112, -0.7886252403],
-    #   u'body_type': u'special',
-    #   u'description': u'Saturn, special',
-    #   u'galactic': [0.0816073528, 0.0971225325],
-    #   u'name': u'Saturn',
-    #   u'parallactic_angle': 1.7129354285,
-    #   u'tags': [u'special'],
-    #   u'uvw_basis': [[-0.7062240338, -0.1212548148, 0.6975276941],
-    #    [-0.26455279870000004, 0.9590535727, -0.10113387880000001],
-    #    [-0.6567034573, -0.2559560795, -0.7093849833]]}]
+    # [{
+    #     u'target': u'Moon',
+    #     u'description': u'Moon,special',
+    #     u'track_duration': 4.0,
+    #     u'slew_time': 53.6153013706,
+    #     u'azel': [3.6399178505, 1.3919397593],
+    #     u'astrometric_radec': [0.180696943, 0.0180189191],
+    #     u'tags': [u'special'],
+    #     u'apparent_radec': [0.1830730793, 0.0169845125],
+    #     u'body_type': u'special',
+    #     u'galactic': [2.0531028499, -1.0774995277],
+    #     u'parallactic_angle': 0.49015412010000003,
+    #     u'name': u'Moon',
+    #     u'uvw_basis': [[0.996376853, -0.0150540303, 0.0837050956],
+    #                    [0.0017334140000000002, 0.9875998825000001, 0.156982379],
+    #                    [-0.08503036010000001, -0.15626851320000001, 0.9840477578000001]]
+    # }]
+
 
 if __name__ == '__main__':
     # Start up the tornado IO loop.

--- a/examples/get_target_descriptions.py
+++ b/examples/get_target_descriptions.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+###############################################################################
+# SKA South Africa (http://ska.ac.za/)                                        #
+# Author: cam@ska.ac.za                                                       #
+# Copyright @ 2013 SKA SA. All rights reserved.                               #
+#                                                                             #
+# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
+# WRITTEN PERMISSION OF SKA SA.                                               #
+###############################################################################
+"""Simple example demonstrating getting pointing information by supplying a
+reference observer location and time.
+
+This example uses HTTP access to katportal, not websocket access.
+"""
+import logging
+import time
+
+import tornado.gen
+
+from katportalclient import KATPortalClient
+
+
+logger = logging.getLogger('katportalclient.example')
+logger.setLevel(logging.INFO)
+
+
+@tornado.gen.coroutine
+def main():
+    # Change URL to point to a valid portal node.  Subarray can be 1 to 4.
+    # Note: if on_update_callback is set to None, then we cannot use the
+    #       KATPortalClient.connect() method (i.e. no websocket access).
+    client = KATPortalClient('http://localhost/api/client',
+                             on_update_callback=None, logger=logger)
+
+    # Get the pointing details of a set of targets from a specified
+    # reference observer location and time.
+    results = yield client.get_target_descriptions(
+        targets='Sun,Jupiter,Moon,Saturn',
+        longitude=10.0,
+        latitude=10.0,
+        altitude=10.0,
+        timestamp=time.time() + 3600)  # one hour in the future
+
+    print results
+
+    # Example output:
+    # [{u'apparent_radec': [5.4887616314, -0.29992498700000003],
+    #   u'astrometric_radec': [5.4847563805, -0.3010704971],
+    #   u'azel': [4.4004411697, 0.0379281938],
+    #   u'body_type': u'special',
+    #   u'description': u'Sun, special',
+    #   u'galactic': [0.529324994, -0.6162473516],
+    #   u'name': u'Sun',
+    #   u'parallactic_angle': 1.3759373506,
+    #   u'tags': [u'special'],
+    #   u'uvw_basis': [[0.09444946950000001, -0.1716449975, 0.9806208710000001],
+    #    [-0.2942402405, 0.9362039477, 0.1922104296],
+    #    [-0.9510530893, -0.30669229400000003, 0.0379191009]]},
+    #  {u'apparent_radec': [3.5236462803, -0.1338425836],
+    #   u'astrometric_radec': [3.5197356490000002, -0.1323132089],
+    #   u'azel': [1.4582693576999999, -1.2722665070999999],
+    #   u'body_type': u'special',
+    #   u'description': u'Jupiter, special',
+    #   u'galactic': [5.5499747102, 0.9469744139],
+    #   u'name': u'Jupiter',
+    #   u'parallactic_angle': -1.4119492999999999,
+    #   u'tags': [u'special'],
+    #   u'uvw_basis': [[-0.9555055370000001, 0.051833308200000004, -0.2903833274],
+    #    [0.039950485200000004, 0.9981095051000001, 0.0467051874],
+    #    [0.2922552436, 0.0330261103, -0.9557699245000001]]},
+    #  {u'apparent_radec': [6.2454304801, -0.0559296419],
+    #   u'astrometric_radec': [6.2526110484, -0.053966023200000005],
+    #   u'azel': [4.4375019073, 0.8184230924],
+    #   u'body_type': u'special',
+    #   u'description': u'Moon, special',
+    #   u'galactic': [1.5751063885, -1.0855229806],
+    #   u'name': u'Moon',
+    #   u'parallactic_angle': 1.2510601122,
+    #   u'tags': [u'special'],
+    #   u'uvw_basis': [[0.7523615662, -0.1143044787, 0.6487577050000001],
+    #    [-0.0368902681, 0.9759746871, 0.2147382554],
+    #    [-0.6577166425000001, -0.18549365580000002, 0.7300691213]]},
+    #  {u'apparent_radec': [4.610326769, -0.3846675644],
+    #   u'astrometric_radec': [4.6059450635, -0.3845379545],
+    #   u'azel': [4.3407421112, -0.7886252403],
+    #   u'body_type': u'special',
+    #   u'description': u'Saturn, special',
+    #   u'galactic': [0.0816073528, 0.0971225325],
+    #   u'name': u'Saturn',
+    #   u'parallactic_angle': 1.7129354285,
+    #   u'tags': [u'special'],
+    #   u'uvw_basis': [[-0.7062240338, -0.1212548148, 0.6975276941],
+    #    [-0.26455279870000004, 0.9590535727, -0.10113387880000001],
+    #    [-0.6567034573, -0.2559560795, -0.7093849833]]}]
+
+if __name__ == '__main__':
+    # Start up the tornado IO loop.
+    # Only a single function to run once, so use run_sync() instead of start()
+    io_loop = tornado.ioloop.IOLoop.current()
+    io_loop.run_sync(main)

--- a/examples/get_target_descriptions.py
+++ b/examples/get_target_descriptions.py
@@ -13,6 +13,7 @@ reference observer location and time.
 This example uses HTTP access to katportal, not websocket access.
 """
 import logging
+import argparse
 import time
 
 import tornado.gen
@@ -29,30 +30,33 @@ def main():
     # Change URL to point to a valid portal node.  Subarray can be 1 to 4.
     # Note: if on_update_callback is set to None, then we cannot use the
     #       KATPortalClient.connect() method (i.e. no websocket access).
-    client = KATPortalClient('http://localhost/api/client/1',
-                             on_update_callback=None, logger=logger)
+    portal_client = KATPortalClient('http://{host}/api/client/1'.format(**vars(args)),
+                                    on_update_callback=None, logger=logger)
 
-    results = yield client.future_targets('20170123-0017')
+    results = yield portal_client.future_targets(
+        '{sb_id_code}'.format(**vars(args)))
     print results
 
     # Example output:
-    # [{u'target': u'Moon', u'slew_time': 53.6153013706, u'track_duration': 4.0}]
+    # [{u'target': u'Moon', u'slew_time': 53.6153013706, u'track_duration': 60.0, u'start_offset': 113.6153013706}]
 
-    client.set_reference_observer_config(
+    portal_client.set_reference_observer_config(
         longitude=10.0,
         latitude=10.0,
         altitude=10.0,
         timestamp=time.time() + 3600)  # one hour in the future
 
-    results = yield client.future_targets_detail('20170123-0017')
+    results = yield portal_client.future_targets_detail(
+        '{sb_id_code}'.format(**vars(args)))
     print results
 
     # Example output:
     # [{
-    #     u'target': u'Moon',
+    #     u'name': u'Moon',
     #     u'description': u'Moon,special',
-    #     u'track_duration': 4.0,
+    #     u'track_duration': 60.0,
     #     u'slew_time': 53.6153013706,
+    #     u'start_offset': 113.6153013706,
     #     u'azel': [3.6399178505, 1.3919397593],
     #     u'astrometric_radec': [0.180696943, 0.0180189191],
     #     u'tags': [u'special'],
@@ -60,14 +64,43 @@ def main():
     #     u'body_type': u'special',
     #     u'galactic': [2.0531028499, -1.0774995277],
     #     u'parallactic_angle': 0.49015412010000003,
-    #     u'name': u'Moon',
     #     u'uvw_basis': [[0.996376853, -0.0150540303, 0.0837050956],
     #                    [0.0017334140000000002, 0.9875998825000001, 0.156982379],
     #                    [-0.08503036010000001, -0.15626851320000001, 0.9840477578000001]]
     # }]
 
+    # To use the default array reference observer, call the set_reference_observer_config
+    # with no parameters. This will also then default to using utc time to calculate the
+    # pointing details
+    portal_client.set_reference_observer_config()
+    results = yield portal_client.future_targets_detail(
+        '{sb_id_code}'.format(**vars(args)))
+    print results
+
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Gets the target list and target pointing descriptions "
+                    "from katportal catalogues.")
+    parser.add_argument(
+        '--host',
+        default='127.0.0.1',
+        help="hostname or IP of the portal server (default: %(default)s).")
+    parser.add_argument(
+        '-s', '--sb-id-code',
+        default=None,
+        dest='sb_id_code',
+        help="The schedule block id code to load the future targets list from")
+    parser.add_argument(
+        '-v', '--verbose',
+        dest='verbose', action="store_true",
+        default=False,
+        help="provide extremely verbose output.")
+    args = parser.parse_args()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
     # Start up the tornado IO loop.
     # Only a single function to run once, so use run_sync() instead of start()
     io_loop = tornado.ioloop.IOLoop.current()

--- a/katportalclient/__init__.py
+++ b/katportalclient/__init__.py
@@ -10,7 +10,8 @@
 
 from client import (
     KATPortalClient, ScheduleBlockNotFoundError, SensorNotFoundError,
-    SensorHistoryRequestError)
+    SensorHistoryRequestError, ScheduleBlockTargetsParsingError,
+    ReferenceObserverConfigNotSet)
 from request import JSONRPCRequest
 
 # BEGIN VERSION CHECK

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -120,7 +120,7 @@ class KATPortalClient(object):
         self._http_client = tornado.httpclient.AsyncHTTPClient()
         self._sitemap = None
         self._sensor_history_states = {}
-        self._reference_observer_config = {}
+        self._reference_observer_config = None
 
     def _get_sitemap(self, url):
         """
@@ -678,7 +678,7 @@ class KATPortalClient(object):
             except:
                 raise ScheduleBlockTargetsParsingError(
                     'There was an error parsing the schedule block (%s) '
-                    'targets attribute: %s', id_code, sb.targets)
+                    'targets attribute: %s', id_code, sb_targets)
         raise tornado.gen.Return(targets_list)
 
     @tornado.gen.coroutine
@@ -760,7 +760,7 @@ class KATPortalClient(object):
             except:
                 raise ScheduleBlockTargetsParsingError(
                     'There was an error parsing the schedule block (%s) '
-                    'targets attribute: %s', id_code, sb.targets)
+                    'targets attribute: %s', id_code, sb_targets)
             config_label = yield self.config_label_for_subarray(
                 int(self.sitemap['sub_nr']))
             target_names = [target.get('name') for target in targets_list]
@@ -821,6 +821,8 @@ class KATPortalClient(object):
             Default: None, katpoint uses current utc time to calculate
             pointing details.
         """
+        if self._reference_observer_config is None:
+            self._reference_observer_config = {}
         self._reference_observer_config['longitude'] = longitude
         self._reference_observer_config['latitude'] = latitude
         self._reference_observer_config['altitude'] = altitude


### PR DESCRIPTION
This consumes the updated sources endpoint (https://github.com/ska-sa/katportal/pull/252) to get the target description and pointing details from a specified reference observer. Also allows you to only get the future targets list as populated in the schedule block by the verification dry run.

Adding `do not merge` label on as I still need to create some unit tests for the new methods.