### PR TITLE
Allow sensor subarray lookup for component names

### DIFF
--- a/katportalclient/__init__.py
+++ b/katportalclient/__init__.py
@@ -10,7 +10,9 @@
 
 from client import (
     KATPortalClient, ScheduleBlockNotFoundError, SensorNotFoundError,
-    SensorHistoryRequestError, ScheduleBlockTargetsParsingError, create_jwt_login_token)
+    SensorHistoryRequestError, ScheduleBlockTargetsParsingError,
+    SubarrayNumberUnknown, SensorLookupError,
+    create_jwt_login_token)
 from request import JSONRPCRequest
 
 # BEGIN VERSION CHECK


### PR DESCRIPTION
A few changes:
- Allow subarray components to be looked up, when the sensor name is not specified.  For it to work with the katportal endpoint, a `"%20"`, i.e. a single space character, is used for the
sensor name.  This will get stripped on katobs side, to lookup just the component name (related changes in ska-sa/katobs/pull/340).
- Updated to use new result format from katportal, so that the KATCP reply does not need to be parsed.  Now raise an exception if the sensor lookup failed.  Related changes in ska-sa/katportal/pull/282.
- The subarray number is no longer specified as a parameter, as it must be determined from the connection URL.  Added a property to help with all the subarray-specific requests.
- Also updated the sitemap and endpoints to match recent changes in katportal.

JIRA: [CB-2064](https://skaafrica.atlassian.net/browse/CB-2064)