### PR TITLE
Update license details to BSD

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,27 @@
+Copyright (c) 2015 SKA South Africa
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the SKA South Africa project nor the names of its
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/basic_websocket_subscription.py
+++ b/examples/basic_websocket_subscription.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2016 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating websocket subscription.
 
 This example connects to katportal via a websocket.  It subscribes to

--- a/examples/example_userlogs_usage.py
+++ b/examples/example_userlogs_usage.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2017 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating userlogs queries.
 
 This example gets lists of tags and userlogs in various ways.

--- a/examples/get_schedule_block_info.py
+++ b/examples/get_schedule_block_info.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2016 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating schedule block information queries.
 
 This example uses HTTP access to katportal, not websocket access.  It uses a

--- a/examples/get_sensor_history.py
+++ b/examples/get_sensor_history.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2016 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating sensor information and history queries.
 
 This example gets lists of sensor names in various ways, and gets the

--- a/examples/get_sensor_info.py
+++ b/examples/get_sensor_info.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2016 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating sensor information queries.
 
 This example gets lists of sensor names in various ways, and gets the

--- a/examples/get_target_descriptions.py
+++ b/examples/get_target_descriptions.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2017 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating getting future pointing information by supplying
 a schedule block id code.
 

--- a/examples/sensor_subarray_lookup.py
+++ b/examples/sensor_subarray_lookup.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2017 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Simple example demonstrating the use of the sensor_subarray_lookup method.
 This method gets the full sensor name based on a generic component and sensor
 name, for a given subarray. This method will return a failed katcp response if

--- a/katportalclient/__init__.py
+++ b/katportalclient/__init__.py
@@ -1,11 +1,5 @@
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Root of katportalclient package."""
 
 from client import (

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1,11 +1,5 @@
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """
 Websocket client and HTTP module for access to katportal webservers.
 """

--- a/katportalclient/request.py
+++ b/katportalclient/request.py
@@ -1,11 +1,5 @@
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Module defining the JSON-RPC request class used by websocket client."""
 
 import uuid

--- a/katportalclient/test/__init__.py
+++ b/katportalclient/test/__init__.py
@@ -1,9 +1,3 @@
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Root of katportalclient test package."""

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -1,11 +1,5 @@
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 """Tests for katportalclient."""
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
 #!/usr/bin/env python
-###############################################################################
-# SKA South Africa (http://ska.ac.za/)                                        #
-# Author: cam@ska.ac.za                                                       #
-# Copyright @ 2013 SKA SA. All rights reserved.                               #
-#                                                                             #
-# THIS SOFTWARE MAY NOT BE COPIED OR DISTRIBUTED IN ANY FORM WITHOUT THE      #
-# WRITTEN PERMISSION OF SKA SA.                                               #
-###############################################################################
+# Copyright 2015 SKA South Africa (http://ska.ac.za/)
+# BSD license - see COPYING for details
 
 from setuptools import setup, find_packages
 
@@ -22,7 +16,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "License :: Other/Proprietary License",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This software should have been released with the 3-clause BSD license.
Added a proper license copyright file and changed all source headers to
refer to it.

Copyright years are when source files were first added to the repo.

Addresses issue #28