### PR TITLE
Revert new katstore changes on master

### DIFF
--- a/examples/get_sensor_history.py
+++ b/examples/get_sensor_history.py
@@ -69,20 +69,15 @@ def main():
                        args.start).strftime('%Y-%m-%dT%H:%M:%SZ'),
                    datetime.utcfromtimestamp(args.end).strftime('%Y-%m-%dT%H:%M:%SZ')))
         if len(sensor_names) == 1:
-            # Request history for just a single sensor - result is
-            # timestamp, value, status
-            #    If value timestamp is also required, then add the additional argument:
-            #        include_value_ts=True
+            # Request history for just a single sensor - result is timestamp, value, status
+            #    If value timestamp is also required, then add the additional argument: include_value_ts=True
             #    result is then timestmap, value_timestmap, value, status
-            additional_fields = args.additional_fields
             history = yield portal_client.sensor_history(
-                sensor_names[0], args.start, args.end,
-                timeout_sec=args.timeout, additional_fields=additional_fields)
+                sensor_names[0], args.start, args.end, timeout_sec=args.timeout)
             histories = {sensor_names[0]: history}
         else:
             # Request history for all the sensors - result is timestamp, value, status
-            #    If value timestamp is also required, then add the additional argument:
-            #        include_value_ts=True
+            #    If value timestamp is also required, then add the additional argument: include_value_ts=True
             #    result is then timestmap, value_timestmap, value, status
             histories = yield portal_client.sensors_histories(
                 sensor_names, args.start, args.end, timeout_sec=args.timeout)
@@ -92,11 +87,9 @@ def main():
             num_samples = len(history)
             print "History for: {} ({} samples)".format(sensor_name, num_samples)
             if num_samples > 0:
+                print "\tindex,timestamp,value,status"
                 for count in range(0, num_samples, args.decimate):
-                    item = history[count]
-                    if count == 0:
-                        print("\tindex,{}".format(",".join(item._fields)))
-                    print "\t{},{}".format(count, item.csv())
+                    print "\t{},{}".format(count, history[count].csv())
 
     # Example: ./get_sensor_history.py -s 1476164224 -e 1476164229 anc_mean_wind_speed
     #
@@ -158,7 +151,6 @@ if __name__ == '__main__':
         dest='verbose', action="store_true",
         default=False,
         help="provide extremely verbose output.")
-
     args = parser.parse_args()
     if args.verbose:
         logger.setLevel(logging.DEBUG)

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -187,7 +187,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         def mock_fetch(url):
             sitemap = {'client':
                        {'websocket': self.websocket_url,
-                        'historic_sensor_values': r"http://0.0.0.0/sensors",
+                        'historic_sensor_values': r"http://0.0.0.0/history",
                         'schedule_blocks': r"http://0.0.0.0/sb",
                         'subarray_sensor_values': r"http://0.0.0.0/sensor-list",
                         'target_descriptions': r"http://0.0.0.0/sources",


### PR DESCRIPTION
This reverts a number of commits made on master than shouldn't be there - they are related to a new katstore feature branch, and should only be on that branch, until the feature work is completed.

Revert from 3ffc66bc28a84b896c9762493edfe78e2fac0fb0 back to
0b39f428ee4487112c2c8eeb3714fe2db11cd7cb.  This takes us back to the release/karoocamv19 branch.

Commands used to revert on the new branch made from master:
```
$ git reset --hard 0b39f428ee4487112c2c8eeb3714fe2db11cd7cb
$ git reset --soft 3ffc66bc28a84b896c9762493edfe78e2fac0fb0
$ git commit
```

The empty diff can be seen here:
https://github.com/ska-sa/katportalclient/compare/release/karoocamv19...user/ajoubert/revert_new_katstore_related_changes?expand=1
