### PR TITLE
MT-409: Test katportalclient against katstore64

### DIFF
--- a/examples/get_sensor_history.py
+++ b/examples/get_sensor_history.py
@@ -68,25 +68,25 @@ def main():
                    datetime.utcfromtimestamp(
                        args.start).strftime('%Y-%m-%dT%H:%M:%SZ'),
                    datetime.utcfromtimestamp(args.end).strftime('%Y-%m-%dT%H:%M:%SZ')))
+        value_time = args.include_value_time
         if len(sensor_names) == 1:
             # Request history for just a single sensor - result is
             # sample_time, value, status
             #    If value timestamp is also required, then add the additional argument:
             #        include_value_time=True
             #    result is then sample_time, value_time, value, status
-            value_time = args.include_value_time
             history = yield portal_client.sensor_history(
                 sensor_names[0], args.start, args.end,
-                include_value_time=value_time, interval=args.interval)
+                include_value_ts=value_time)
             histories = {sensor_names[0]: history}
         else:
             # Request history for all the sensors - result is sample_time, value, status
             #    If value timestamp is also required, then add the additional argument:
             #        include_value_time=True
             #    result is then sample_time, value_time, value, status
-            histories = yield portal_client.sensors_histories(
-                sensor_names, args.start, args.end, include_value_time=value_time,
-                interval=args.interval)
+            histories = yield portal_client.sensors_histories(sensor_names, args.start,
+                                                              args.end,
+                                                              include_value_ts=value_time)
 
         print "Found {} sensors.".format(len(histories))
         for sensor_name, history in histories.items():

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1237,7 +1237,7 @@ class KATPortalClient(object):
 
     @tornado.gen.coroutine
     def sensor_history(self, sensor_name, start_time_sec, end_time_sec,
-                       include_value_time=False, interval=0):
+                       include_value_ts=False, timeout_sec=0):
         """Return time history of sample measurements for a sensor.
 
         For a list of sensor names, see :meth:`.sensors_list`.
@@ -1251,12 +1251,12 @@ class KATPortalClient(object):
             (1970-01-01 UTC).
         end_time_sec: float
             End time for sample history query, in seconds since the UNIX epoch.
-        include_value_time: bool
+        include_value_ts: bool
             Flag to also include value sample_time in addition to time series
             sample time in the result.
             Default: False.
-        interval: int
-            The resampling interval in seconds. 0 to disable. Currently NOT supported.
+        timeout_sec: int
+            This parameter is no longer support. Here for backwards compatibility
 
         Returns
         -------
@@ -1275,12 +1275,17 @@ class KATPortalClient(object):
             - If there was an error submitting the request.
             - If the request timed out
         """
+
+        if timeout_sec != 0:
+            self._logger.warn(
+                "timeout_sec is no longer supported. Default tornado timeout is used")
+
         params = {
             'sensor': sensor_name,
             'start_time': start_time_sec,
             'end_time': end_time_sec,
             'limit': MAX_SAMPLES_PER_HISTORY_QUERY,
-            'include_value_time': include_value_time
+            'include_value_time': include_value_ts
         }
 
         url = url_concat(
@@ -1308,7 +1313,7 @@ class KATPortalClient(object):
 
     @tornado.gen.coroutine
     def sensors_histories(self, filters, start_time_sec, end_time_sec,
-                          include_value_time=False, interval=0):
+                          include_value_ts=False, timeout_sec=0):
         """Return time histories of sample measurements for multiple sensors.
 
         Finds the list of available sensors in the system that match the
@@ -1326,12 +1331,12 @@ class KATPortalClient(object):
             (1970-01-01 UTC).
         end_time_sec: float
             End time for sample history query, in seconds since the UNIX epoch.
-        include_value_time: bool
+        include_value_ts: bool
             Flag to also include value sample_time in addition to time series
             sample sample in the result.
             Default: False.
-        interval: int
-            The resampling interval in seconds. 0 to disable.
+        timeout_sec: int
+            This parameter is no longer support. Here for backwards compatibility
 
         Returns
         -------
@@ -1352,13 +1357,13 @@ class KATPortalClient(object):
         SensorNotFoundError:
             - If any of the filters were invalid regular expression patterns.
         """
+
         sensors = yield self.sensor_names(filters)
         histories = {}
         for sensor in sensors:
             histories[sensor] = yield self.sensor_history(
                 sensor, start_time_sec, end_time_sec,
-                include_value_time=include_value_time,
-                interval=interval)
+                include_value_ts=include_value_ts, timeout_sec=timeout_sec)
         raise tornado.gen.Return(histories)
 
     @tornado.gen.coroutine

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1256,7 +1256,7 @@ class KATPortalClient(object):
             sample time in the result.
             Default: False.
         interval: int
-            The resampling interval in seconds. 0 to disable.
+            The resampling interval in seconds. 0 to disable. Currently NOT supported.
 
         Returns
         -------
@@ -1280,9 +1280,9 @@ class KATPortalClient(object):
             'start_time': start_time_sec,
             'end_time': end_time_sec,
             'limit': MAX_SAMPLES_PER_HISTORY_QUERY,
-            'include_value_time': include_value_time,
-            'interval': interval
+            'include_value_time': include_value_time
         }
+
         url = url_concat(
             self.sitemap['historic_sensor_values'] + '/query', params)
         self._logger.debug("Sensor history request: %s", url)

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -950,7 +950,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             contains=sensor_name)
 
         samples = yield self._portal_client.sensor_history(
-            sensor_name, start_time_sec=0, end_time_sec=time.time(), include_value_time=False)
+            sensor_name, start_time_sec=0, end_time_sec=time.time(), include_value_ts=False)
         # expect exactly 4 samples
         self.assertTrue(len(samples) == 4)
 
@@ -978,7 +978,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             contains=sensor_name)
 
         samples = yield self._portal_client.sensor_history(
-            sensor_name, start_time_sec=0, end_time_sec=time.time(), include_value_time=True)
+            sensor_name, start_time_sec=0, end_time_sec=time.time(), include_value_ts=True)
         # expect exactly 3 samples
         self.assertTrue(len(samples) == 3)
 
@@ -1075,8 +1075,9 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                 sensor_names[0],
                 sensor_names[1]])
 
-        histories = yield self._portal_client.sensors_histories(
-            sensor_name_filter, start_time_sec=0, end_time_sec=time.time())
+        histories = yield self._portal_client.sensors_histories(sensor_name_filter,
+                                                                start_time_sec=0,
+                                                                end_time_sec=time.time())
         # expect exactly 2 lists of samples
         self.assertTrue(len(histories) == 2)
         # expect keys to match the 2 sensor names


### PR DESCRIPTION
Removed support for interval for new katstore as the returned datatype is not supported.