### PR TITLE
Add multiple sensor readings request

### DIFF
--- a/examples/get_latest_sensor_value.py
+++ b/examples/get_latest_sensor_value.py
@@ -29,7 +29,7 @@ def main():
 
     # Get the names of sensors matching the patterns
     # See examples/get_sensor_info.py for details on sensor name pattern matching
-    sensor_names = yield portal_client.sensor_names(args.sensors)
+    sensor_names = args.sensors  # yield portal_client.sensor_names(args.sensors)
     print("\nMatching sensor names for pattern {}: {}".format(args.sensors, sensor_names))
 
     # Fetch the readings for the sensors found.
@@ -38,13 +38,13 @@ def main():
     else:
         for sensor_name in sensor_names:
             try:
-                sensor_value = yield portal_client.sensor_value(sensor_name,
-                                                                include_value_ts=True)
+                sensor_values = yield portal_client.sensor_values(sensor_name,
+                                                                          include_value_ts=True)
             except SensorNotFoundError as exc:
                 print("\n", exc)
                 continue
             print("\nValue for sensor {}:".format(sensor_name))
-            print(sensor_value)
+            print(sensor_values)
 
 
 if __name__ == '__main__':

--- a/examples/get_latest_sensor_value.py
+++ b/examples/get_latest_sensor_value.py
@@ -29,7 +29,7 @@ def main():
 
     # Get the names of sensors matching the patterns
     # See examples/get_sensor_info.py for details on sensor name pattern matching
-    sensor_names = args.sensors  # yield portal_client.sensor_names(args.sensors)
+    sensor_names = yield portal_client.sensor_names(args.sensors)
     print("\nMatching sensor names for pattern {}: {}".format(args.sensors, sensor_names))
 
     # Fetch the readings for the sensors found.
@@ -38,13 +38,13 @@ def main():
     else:
         for sensor_name in sensor_names:
             try:
-                sensor_values = yield portal_client.sensor_values(sensor_name,
-                                                                          include_value_ts=True)
+                sensor_value = yield portal_client.sensor_value(sensor_name,
+                                                                include_value_ts=True)
             except SensorNotFoundError as exc:
                 print("\n", exc)
                 continue
             print("\nValue for sensor {}:".format(sensor_name))
-            print(sensor_values)
+            print(sensor_value)
 
 
 if __name__ == '__main__':

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1308,7 +1308,7 @@ class KATPortalClient(object):
                 status=result_to_format['status']))
 
     @tornado.gen.coroutine
-    def sensor_readings(self, filters, include_value_ts=False):
+    def sensor_values(self, filters, include_value_ts=False):
         """Return a list of latest readings of the sensors matching the
         specified pattern.
 

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1308,6 +1308,67 @@ class KATPortalClient(object):
                 status=result_to_format['status']))
 
     @tornado.gen.coroutine
+    def sensor_readings(self, filters, include_value_ts=False):
+        """Return a list of latest readings of the sensors matching the
+        specified pattern.
+
+        Parameters
+        ----------
+        filters: str or list of str
+            List of regular expression patterns to match.
+
+            e.g. '((m0\\d\\d)|(s0\\d\\d\\d))_observer' will return the
+            'observer' sensor reading for all antennas.
+
+            See :meth:`.set_sampling_strategies` for more detail.
+
+        Returns
+        -------
+        dict:
+            Dict of sensor name strings and their latest readings.
+
+        Raises
+        -------
+        SensorNotFoundError:
+            - If no information was available for the requested filter.
+        InvalidResponseError:
+            - When the katportal service returns invalid JSON
+        """
+        url = self.sitemap['monitor'] + '/list-sensors/all'
+
+        if isinstance(filters, basestring):
+            filters = [filters]
+
+        results_to_return = {}
+
+        for filt in filters:
+            response = yield self._http_client.fetch(
+                "{}?reading_only=1&name_filter={}$".format(url, filt))
+            try:
+                results = json.loads(response.body)
+            except json.JSONError:
+                raise InvalidResponseError(
+                    "Request to {} did not respond with valid JSON".format(url))
+
+            if len(results) == 0:
+                raise SensorNotFoundError("No values for filter {} found".format(filt))
+
+            for result in results:
+                if include_value_ts:
+                    results_to_return[result['name']] = SensorSampleValueTs(
+                        timestamp=result['time'],
+                        value_timestamp=result['value_ts'],
+                        value=result['value'],
+                        status=result['status'])
+                else:
+                    results_to_return[result['name']] = SensorSample(
+                        timestamp=result['time'],
+                        value=result['value'],
+                        status=result['status'])
+
+        raise tornado.gen.Return(results_to_return)
+
+    @tornado.gen.coroutine
     def sensor_history(self, sensor_name, start_time_sec, end_time_sec,
                        include_value_ts=False, timeout_sec=300):
         """Return time history of sample measurements for a sensor.

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -822,6 +822,86 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         assert res == expected_result
 
     @gen_test
+    def test_sensor_readings_invalid_results(self):
+        """test that we handle the monitor server returning an invalid string"""
+        self.mock_http_async_client().fetch.side_effect = fake_http_response('')
+        with self.assertRaises(InvalidResponseError):
+            yield self._portal_client.sensor_readings("INVALID_FILTER")
+
+    @gen_test
+    def test_sensor_readings_no_results(self):
+        """Test that we handle no matches"""
+        self.mock_http_async_client().fetch.side_effect = fake_http_response('[]')
+        with self.assertRaises(SensorNotFoundError):
+            yield self._portal_client.sensor_readings("INVALID_FILTER")
+
+    @gen_test
+    def test_sensor_readings_one_filter_multiple_matches(self):
+        """Test that we handle multiple matches correctly with one filter"""
+
+        mon_response = ('[{"status":"nominal",'
+                        '"name":"anc_tfr_m018_l_band_offset","component":"anc",'
+                        '"value":43680.0,'
+                        '"value_ts":1530713112,"time":1531302437},'
+                        '{"status":"nominal",'
+                        '"name":"some_other_sample","component":"anc","value":43680.0,'
+                        '"value_ts":111.111,"time":222.222}]')
+
+        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        result = yield self._portal_client.sensor_readings("ARBITRARY_FILTER")
+        expected_result = {"anc_tfr_m018_l_band_offset" : SensorSample(timestamp=1531302437,
+                                                                       value=43680.0,
+                                                                       status='nominal'),
+                           "some_other_sample" : SensorSample(timestamp=222.222,
+                                                              value=43680.0,
+                                                              status='nominal')
+                          }
+        assert result == expected_result
+
+        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        result = yield self._portal_client.sensor_readings("ARBITRARY_FILTER",
+                                                           include_value_ts=True)
+        expected_result = {"anc_tfr_m018_l_band_offset" : SensorSampleValueTs(timestamp=1531302437,
+                                                                              value_timestamp=1530713112,
+                                                                              value=43680.0,
+                                                                              status='nominal'),
+                           "some_other_sample" : SensorSampleValueTs(timestamp=222.222,
+                                                                     value_timestamp=111.111,
+                                                                     value=43680.0,
+                                                                     status='nominal')
+                          }
+        assert result == expected_result
+
+    @gen_test
+    def test_sensor_readings_multiple_filters_multiple_matches(self):
+        """Test that we handle multiple matches correctly with multiple filters"""
+
+        mon_response_0 = ('[{"status":"nominal",'
+                          '"name":"some_other_sample_0",'
+                          '"component":"anc","value":43480.0,'
+                          '"value_ts":110.111,"time":220.222}]')
+        mon_response_1 = ('[{"status":"nominal",'
+                          '"name":"some_other_sample_1",'
+                          '"component":"anc","value":43580.0,'
+                          '"value_ts":111.111,"time":221.222}]')
+
+        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+            valid_responses=[mon_response_0, mon_response_1],
+            invalid_responses=['1error', '2error'],
+            containses=["sample_0","sample_1"]
+            )
+
+        expected_result = {"some_other_sample_0" : SensorSample(timestamp=220.222,
+                                                                value=43480.0,
+                                                                status='nominal'),
+                           "some_other_sample_1" : SensorSample(timestamp=221.222,
+                                                                value=43580.0,
+                                                                status='nominal')
+                          }
+        res = yield self._portal_client.sensor_readings(["some_other_sample_0", "some_other_sample_1"])
+        assert res == expected_result, res
+
+    @gen_test
     def test_sensor_history_single_sensor_with_value_ts(self):
         """Test that time ordered data with value_timestamp is received for a single sensor request."""
         history_base_url = self._portal_client.sitemap[
@@ -1555,7 +1635,6 @@ def fake_http_response(response_string):
     future = concurrent.Future()
     future.set_result(result)
     return [future]
-
 
 def buffer_bytes_io(message):
     """Return a string as BytesIO, in Python 2 and 3."""


### PR DESCRIPTION
This PR is to add a katportalclient function that will allow a user to get the readings of multiple sensors matching the provided regex pattern in a single request.

This is to address an issue uncovered during USE integration testing where concurrent use of the existing 'sensor_value' function would time out in large arrays when requesting the value of a sensor that appears on all the receptor proxies. This same function could be used sequentially but it takes very long to complete the full sensor value query for all the antennas.


46 antennas (site) | Tests | Sequential method (seconds) | Concurrent method (seconds) | Number of requests that timed out with concurrent method | New sensor_readings function (seconds)
-- | -- | -- | -- | -- | --
  |   |   |   |   |  
  | 1 | 83.20171714 | 27.66871595 | 17 | 1.62815094
  | 2 | 79.9378612 | 26.84987283 | 14 | 1.597753048
  | 3 | 80.16674399 | 25.84432793 | 11 | 1.628293037
  | 4 | 78.77246594 | 25.53388405 | 11 | 1.734354973
  | 5 | 76.92577791 | 26.34447694 | 10 | 1.7288661
  |   |   |   |   |  
  | Avg: | 79.80091324 | 26.44825554 | 12.6 | 1.66348362
  |   |   |   |   |  
5 antennas (dev) |   |   |   |   |  
  | 1 | 2.605043888 | 0.7106490135 | 0 | 0.4347200394
  | 2 | 1.921550035 | 0.7513661385 | 0 | 0.4040129185

