### PR TITLE
Request a list of sb_ids associated with a given capture block ID

### DIFF
--- a/examples/get_schedule_block_info.py
+++ b/examples/get_schedule_block_info.py
@@ -80,7 +80,6 @@ def main():
         #              u'data_quality': None}
 
     cb_ids = ['1555494792.25']
-    # cb_ids = yield portal_client.schedule_blocks_completed()
     if len(cb_ids) > 0:
         cb_detail = yield portal_client.sb_ids_by_capture_block(cb_ids[0])
         print("\nSchedule block IDs for Capture block ID {}:\n{}\n".format(cb_ids[0], cb_detail))

--- a/examples/get_schedule_block_info.py
+++ b/examples/get_schedule_block_info.py
@@ -31,12 +31,12 @@ def main():
                                     on_update_callback=None, logger=logger)
 
     # Get the IDs of schedule blocks assigned to the subarray specified above.
+    # sb_ids = ['20190417-0001']
     sb_ids = yield portal_client.schedule_blocks_assigned()
     print("\nSchedule block IDs on subarray {}\n{}".format(args.sub_nr, sb_ids))
     # Example output:
     #   Schedule block IDs on subarray 1:
     #   [u'20161010-0001', u'20161010-0002', u'20161010-0003']
-
     # Fetch the details for one of the schedule blocks found.
     if len(sb_ids) > 0:
         sb_detail = yield portal_client.schedule_block_detail(sb_ids[0])
@@ -79,6 +79,14 @@ def main():
         #              u'outcome': u'UNKNOWN',
         #              u'data_quality': None}
 
+    cb_ids = ['1555494792.25']
+    # cb_ids = yield portal_client.schedule_blocks_completed()
+    if len(cb_ids) > 0:
+        cb_detail = yield portal_client.sb_ids_by_capture_block(cb_ids[0])
+        print("\nSchedule block IDs for Capture block ID {}:\n{}\n".format(cb_ids[0], cb_detail))
+        # Example output:
+        # Schedule block IDs for given Capture block ID 1555494792:
+        # [u'20190417-0001']
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/examples/get_schedule_block_info.py
+++ b/examples/get_schedule_block_info.py
@@ -31,12 +31,12 @@ def main():
                                     on_update_callback=None, logger=logger)
 
     # Get the IDs of schedule blocks assigned to the subarray specified above.
-    # sb_ids = ['20190417-0001']
     sb_ids = yield portal_client.schedule_blocks_assigned()
     print("\nSchedule block IDs on subarray {}\n{}".format(args.sub_nr, sb_ids))
     # Example output:
     #   Schedule block IDs on subarray 1:
     #   [u'20161010-0001', u'20161010-0002', u'20161010-0003']
+
     # Fetch the details for one of the schedule blocks found.
     if len(sb_ids) > 0:
         sb_detail = yield portal_client.schedule_block_detail(sb_ids[0])
@@ -79,13 +79,6 @@ def main():
         #              u'outcome': u'UNKNOWN',
         #              u'data_quality': None}
 
-    cb_ids = ['1555494792.25']
-    if len(cb_ids) > 0:
-        cb_detail = yield portal_client.sb_ids_by_capture_block(cb_ids[0])
-        print("\nSchedule block IDs for Capture block ID {}:\n{}\n".format(cb_ids[0], cb_detail))
-        # Example output:
-        # Schedule block IDs for given Capture block ID 1555494792:
-        # [u'20190417-0001']
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1091,7 +1091,10 @@ class KATPortalClient(object):
                     'COMPLETED': observation completed naturally (may have been
                                  successful, or failed).
                     'INTERRUPTED': observation was stopped or cancelled by a user or
-                                   the system.
+                                   the system
+                capture_block_id:
+                    Capture block identifier set when capture session initiates.
+                    For example: ``1555494792``.
                 sub_nr: int
                     The number of the subarray the observation is scheduled on.
 
@@ -1109,6 +1112,7 @@ class KATPortalClient(object):
                 "Invalid schedule block ID: " + id_code)
         raise tornado.gen.Return(schedule_block)
 
+    #TODO: Might need to add a usage script in ../examples
     @tornado.gen.coroutine
     def sb_ids_by_capture_block(self, capture_block_id):
         """Return list of approved observation schedule blocks.
@@ -1124,7 +1128,7 @@ class KATPortalClient(object):
         Parameters
         ----------
         capture_block_id: str
-            Capture block identifier. For example: ``1555494792``.
+            Capture block identifier. For example: ``1556067480``.
 
         Returns
         -------
@@ -1137,18 +1141,14 @@ class KATPortalClient(object):
         ScheduleBlockNotFoundError:
             If no schedule block ID was available for the requested capture block.
         """
-        url = self.sitemap['capture_blocks'] + '/' + capture_block_id
+        url = self.sitemap['capture_blocks'] + '/sb/' + capture_block_id
         response = yield self._http_client.fetch(url)
         response = json.loads(response.body)
-        cb_schedule_blocks = response['result']
-        cb_results = []
-        for cb_schedule_block in cb_schedule_blocks:
-            if (cb_schedule_block['capture_block_id'] == capture_block_id and
-                    cb_schedule_block['type'] == 'OBSERVATION'):
-                cb_results.append(cb_schedule_block['capture_block_id'])
+        capture_block = response['result']
+        if not capture_block:
             raise ScheduleBlockNotFoundError(
-                    "Invalid capture block ID: " + capture_block_id)
-        raise tornado.gen.Return(cb_schedule_block)
+                "Invalid capture block ID: " + capture_block_id)
+        raise tornado.gen.Return(capture_block)
 
     def _extract_sensors_details(self, json_text):
         """Extract and return list of sensor names from a JSON response."""

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1112,13 +1112,13 @@ class KATPortalClient(object):
                 "Invalid schedule block ID: " + id_code)
         raise tornado.gen.Return(schedule_block)
 
-    #TODO: Might need to add a usage script in ../examples
     @tornado.gen.coroutine
     def sb_ids_by_capture_block(self, capture_block_id):
-        """Return list of approved observation schedule blocks.
+        """Return list of observation schedule blocks associated with the given
+        capture block ID.
 
-        The schedule blocks have already approved. For detail about
-        a schedule block, use :meth:`.schedule_block_detail`.
+        Capture block IDs are provided by SDP and link to the science data
+        archive.
 
         .. note::
 
@@ -1128,27 +1128,19 @@ class KATPortalClient(object):
         Parameters
         ----------
         capture_block_id: str
-            Capture block identifier. For example: ``1556067480``.
+            Capture block identifier. For example: '1556067480'.
 
         Returns
         -------
         list:
-            List of scheduled block ID strings.  Ordered according to
-            priority of the schedule blocks (first has hightest priority).
+            List of matching schedule block ID strings.  Could be empty.
 
-        Raises
-        ------
-        ScheduleBlockNotFoundError:
-            If no schedule block ID was available for the requested capture block.
         """
         url = self.sitemap['capture_blocks'] + '/sb/' + capture_block_id
         response = yield self._http_client.fetch(url)
         response = json.loads(response.body)
-        capture_block = response['result']
-        if not capture_block:
-            raise ScheduleBlockNotFoundError(
-                "Invalid capture block ID: " + capture_block_id)
-        raise tornado.gen.Return(capture_block)
+        schedule_block_ids = response['result']
+        raise tornado.gen.Return(schedule_block_ids)
 
     def _extract_sensors_details(self, json_text):
         """Extract and return list of sensor names from a JSON response."""

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -594,23 +594,21 @@ class TestKATPortalClient(WebSocketBaseTestCase):
 
     @gen_test
     def test_sb_ids_by_capture_block(self):
-        """Test with no capture block IDs on a subarray."""
+        """Test with a givrn capture block ID."""
         capture_block_base_url = self._portal_client.sitemap[
             'capture_blocks']
+        capture_block_id = "1556092345"
 
         self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
             valid_response=r"""
                 {"result":
-                    "[{\"capture_block_id\":\"1556092345\",\"owner\":\"CAM\",\"type\":\"OBSERVATION\",\"sub_nr\":1},
-                      {\"capture_block_id\":\"1556062104\",\"owner\":\"CAM\",\"type\":\"OBSERVATION\",\"sub_nr\":2}
-                     ]"
+                     [20190424-0009]"
                 }""",
             invalid_response="""{"result":null}""",
-            starts_with=capture_block_base_url)
-
-        sb_ids = yield self._portal_client.sb_ids_by_capture_block()
-
-        self.assertTrue(len(sb_ids) == 0, "Expect no schedule block IDs")
+            starts_with=capture_block_base_url,
+            contains=capture_block_id)
+        with self.assertRaises(ScheduleBlockNotFoundError):
+            yield self._portal_client.sb_ids_by_capture_block("155610571c")
 
     @gen_test
     def test_sensor_names_single_sensor_valid(self):

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -594,7 +594,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
 
     @gen_test
     def test_sb_ids_by_capture_block(self):
-        """Test with a givrn capture block ID."""
+        """Test schedule block IDs are correctly extracted using a given capture block ID."""
         capture_block_base_url = self._portal_client.sitemap[
             'capture_blocks']
         capture_block_id = "1556092345"
@@ -605,10 +605,13 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                      [20190424-0009]"
                 }""",
             invalid_response="""{"result":null}""",
-            starts_with=capture_block_base_url,
-            contains=capture_block_id)
-        with self.assertRaises(ScheduleBlockNotFoundError):
-            yield self._portal_client.sb_ids_by_capture_block("155610571c")
+            starts_with=capture_block_base_url)
+        sb_ids = yield self._portal_client.sb_ids_by_capture_block(capture_block_id)
+
+        # Verify that sb_id has been returned to the list
+        self.assertTrue(len(sb_ids) == 1,
+                        "Expect exactly 1 schedule block ID")
+        self.assertIn('20190424-0009', sb_ids)
 
     @gen_test
     def test_sensor_names_single_sensor_valid(self):


### PR DESCRIPTION
In this PR, added a method on katportalclient for users to query katportal for sb IDs associated with a given capture block ID. An example is shown on `examples/get_schedule_block_info.py`

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] I have requested >= 2 reviewers for this PR?
- [x] I have commented my code, particularly in hard-to-understand areas?
- [ ] I have made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-660](https://skaafrica.atlassian.net/browse/MT-660)