### PR TITLE
Make katportalclient work on newer versions of Tornado

### DIFF
--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -193,8 +193,7 @@ class KATPortalClient(object):
         """
         try:
             if self._session_id is not None:
-                yield self._init_sitemap()
-                url = self.sitemap['authorization'] + '/user/logout'
+                url = (yield self.get_sitemap())['authorization'] + '/user/logout'
                 response = yield self.authorized_fetch(
                     url=url, auth_token=self._session_id, method='POST', body='{}')
                 self._logger.info("Logout result: %s", response.body)
@@ -221,8 +220,8 @@ class KATPortalClient(object):
 
         """
         login_token = create_jwt_login_token(username, password)
-        yield self._init_sitemap()
-        url = self.sitemap['authorization'] + '/user/verify/' + role
+        authorization = (yield self.get_sitemap())['authorization']
+        url = authorization + '/user/verify/' + role
         response = yield self.authorized_fetch(url=url, auth_token=login_token)
 
         try:
@@ -231,7 +230,7 @@ class KATPortalClient(object):
                 self._session_id = response_json.get('session_id')
                 self._current_user_id = response_json.get('user_id')
 
-                login_url = self.sitemap['authorization'] + '/user/login'
+                login_url = authorization + '/user/login'
                 response = yield self.authorized_fetch(
                     url=login_url, auth_token=self._session_id,
                     method='POST', body='')
@@ -268,7 +267,7 @@ class KATPortalClient(object):
         """
         Fetches the sitemap from the specified URL.
 
-        See :meth:`.sitemap` for details, including the return value. This
+        See :meth:`.get_sitemap` for details, including the return value. This
         function may be run on a worker thread, so it must take care not to
         touch any members that are not thread-safe.
 
@@ -321,8 +320,7 @@ class KATPortalClient(object):
     def _init_sitemap(self):
         """Initializes the sitemap if it is not already initialized.
 
-        This should always be called before accessing :meth:`.sitemap`.
-        See :meth:`.sitemap` for details.
+        See :meth:`.get_sitemap` for details.
         """
 
         if not self._sitemap:
@@ -334,11 +332,43 @@ class KATPortalClient(object):
         """
         Returns the sitemap using the URL specified during instantiation.
 
+        This method is kept for convenience and backwards compatibility, but
+        should not be used in code that runs on a Tornado event loop as it
+        may block the event loop if the sitemap has not yet been retrieved.
+        Use :meth:`.get_sitemap` instead.
+        """
+        if not self._sitemap:
+            # Properties can't be asynchronous, so we have to resort to a
+            # separate IOLoop on a helper thread to do the work. Using
+            # Tornado's synchronous HTTPClient works in older Tornado
+            # versions, but fails on newer ones because it's implemented
+            # with IOLoop.run_sync and asyncio doesn't allow a secondary
+            # event loop to be used on the same thread as the primary.
+            def worker():
+                io_loop = tornado.ioloop.IOLoop()
+                sitemap = io_loop.run_sync(lambda: self._get_sitemap(self._url))
+                io_loop.close()
+                return sitemap
+
+            self._logger.warning("Fetching sitemap synchronously")
+            with concurrent.futures.ThreadPoolExecutor(1) as executor:
+                self._sitemap = executor.submit(worker).result()
+        return self._sitemap
+
+    @tornado.gen.coroutine
+    def get_sitemap(self):
+        """
+        Returns the sitemap using the URL specified during instantiation.
+
         The portal webserver provides a sitemap with a number of URLs.  The
         endpoints could change over time, but the keys to access them will not.
         The websever is only queried once, the first time the property is
         accessed.  Typically users will not need to access the sitemap
         directly - the class's methods make use of it.
+
+        The sitemap can also be accessed synchronously via the :meth:`.sitemap`
+        property, but that may block the Tornado event loop the first time it
+        used.
 
         Returns
         -------
@@ -369,26 +399,32 @@ class KATPortalClient(object):
                     specified schedule block
 
         """
-        if not self._sitemap:
-            # Properties can't be asynchronous, so we have to resort to a
-            # separate IOLoop on a helper thread to do the work. Using
-            # Tornado's synchronous HTTPClient works in older Tornado
-            # versions, but fails on newer ones because it's implemented
-            # with IOLoop.run_sync and asyncio doesn't allow a secondary
-            # event loop to be used on the same thread as the primary.
-            def worker():
-                io_loop = tornado.ioloop.IOLoop()
-                sitemap = io_loop.run_sync(lambda: self._get_sitemap(self._url))
-                io_loop.close()
-                return sitemap
+        yield self._init_sitemap()
+        raise tornado.gen.Return(self._sitemap)
 
-            self._logger.warning("Fetching sitemap synchronously")
-            with concurrent.futures.ThreadPoolExecutor(1) as executor:
-                self._sitemap = executor.submit(worker).result()
-        return self._sitemap
+    @staticmethod
+    def _parse_sub_nr(sitemap):
+        """Implementation of :meth:`.sub_nr` and :meth:`.get_sub_nr`."""
+        try:
+            sub_nr = int(sitemap['sub_nr'])
+        except ValueError:
+            raise SubarrayNumberUnknown(
+                "Connection URL is not subarray-specific - sitemap sub_nr: '{}'"
+                .format(sitemap['sub_nr']))
+        return sub_nr
 
     @property
     def sub_nr(self):
+        """Returns subarray number, if available.
+
+        This is equivalent to :meth:`.get_sub_nr`, but synchronous. It will
+        block the Tornado event loop if the sitemap has not yet been
+        retrieved, so :meth:`.get_sub_nr` is preferred.
+        """
+        return self._parse_sub_nr(self.sitemap)
+
+    @tornado.gen.coroutine
+    def get_sub_nr(self):
         """Returns subarray number, if available.
 
         This number is based on the URL used to connect to
@@ -404,13 +440,8 @@ class KATPortalClient(object):
         SubarrayNumberUnknown:
             - If the subarray number could not be determined.
         """
-        try:
-            sub_nr = int(self.sitemap['sub_nr'])
-        except ValueError:
-            raise SubarrayNumberUnknown(
-                "Connection URL is not subarray-specific - sitemap sub_nr: '{}'"
-                .format(self.sitemap['sub_nr']))
-        return sub_nr
+        sub_nr = self._parse_sub_nr((yield self.get_sitemap()))
+        raise tornado.gen.Return(sub_nr)
 
     @property
     def is_connected(self):
@@ -437,15 +468,15 @@ class KATPortalClient(object):
         # The lock is used to ensure only a single connection can be made
         with (yield self._ws_connecting_lock.acquire()):
             self._disconnect_issued = False
+            websocket_url = (yield self.get_sitemap())['websocket']
             if not self.is_connected:
-                yield self._init_sitemap()
                 self._logger.debug(
-                    "Connecting to websocket %s", self.sitemap['websocket'])
+                    "Connecting to websocket %s", websocket_url)
                 try:
                     if self._heart_beat_timer.is_running():
                         self._heart_beat_timer.stop()
                     self._ws = yield websocket_connect(
-                        self.sitemap['websocket'],
+                        websocket_url,
                         on_message_callback=self._websocket_message,
                         connect_timeout=WS_CONNECT_TIMEOUT)
                     if reconnecting:
@@ -455,7 +486,7 @@ class KATPortalClient(object):
                 except Exception:
                     self._logger.exception(
                         'Could not connect websocket to %s',
-                        self.sitemap['websocket'])
+                        websocket_url)
                     if reconnecting:
                         self._logger.info(
                             'Retrying connection in %s seconds...', WS_RECONNECT_INTERVAL)
@@ -999,10 +1030,9 @@ class KATPortalClient(object):
         SubarrayNumberUnknown:
             - If a subarray number could not be determined.
         """
-        yield self._init_sitemap()
-        url = self.sitemap['schedule_blocks'] + '/scheduled'
+        url = (yield self.get_sitemap())['schedule_blocks'] + '/scheduled'
         response = yield self._http_client.fetch(url)
-        results = self._extract_schedule_blocks(response.body, self.sub_nr)
+        results = self._extract_schedule_blocks(response.body, (yield self.get_sub_nr()))
         raise tornado.gen.Return(results)
 
     @tornado.gen.coroutine
@@ -1136,8 +1166,7 @@ class KATPortalClient(object):
         ScheduleBlockNotFoundError:
             If no information was available for the requested schedule block.
         """
-        yield self._init_sitemap()
-        url = self.sitemap['schedule_blocks'] + '/' + id_code
+        url = (yield self.get_sitemap())['schedule_blocks'] + '/' + id_code
         response = yield self._http_client.fetch(url)
         response = json.loads(response.body)
         schedule_block = response['result']
@@ -1170,8 +1199,7 @@ class KATPortalClient(object):
             List of matching schedule block ID strings.  Could be empty.
 
         """
-        yield self._init_sitemap()
-        url = self.sitemap['capture_blocks'] + '/sb/' + capture_block_id
+        url = (yield self.get_sitemap())['capture_blocks'] + '/sb/' + capture_block_id
         response = yield self._http_client.fetch(url)
         response = json.loads(response.body)
         schedule_block_ids = response['result']
@@ -1224,8 +1252,7 @@ class KATPortalClient(object):
         SensorNotFoundError:
             - If any of the filters were invalid regular expression patterns.
         """
-        yield self._init_sitemap()
-        url = self.sitemap['historic_sensor_values'] + '/sensors'
+        url = (yield self.get_sitemap())['historic_sensor_values'] + '/sensors'
         if isinstance(filters, basestring):
             filters = [filters]
         results = set()
@@ -1289,8 +1316,7 @@ class KATPortalClient(object):
             - If no information was available for the requested sensor name.
             - If the sensor name was not a unique match for a single sensor.
         """
-        yield self._init_sitemap()
-        url = self.sitemap['historic_sensor_values'] + '/sensors'
+        url = (yield self.get_sitemap())['historic_sensor_values'] + '/sensors'
         response = yield self._http_client.fetch("{}?sensors={}".format(url, sensor_name))
         results = self._extract_sensors_details(response.body)
         if len(results) == 0:
@@ -1341,8 +1367,7 @@ class KATPortalClient(object):
         InvalidResponseError:
             - When the katportal service returns invalid JSON
         """
-        yield self._init_sitemap()
-        url = self.sitemap['monitor'] + '/list-sensors/all'
+        url = (yield self.get_sitemap())['monitor'] + '/list-sensors/all'
 
         response = yield self._http_client.fetch(
             "{}?reading_only=1&name_filter=^{}$".format(url, sensor_name))
@@ -1415,8 +1440,7 @@ class KATPortalClient(object):
         InvalidResponseError:
             - When the katportal service returns invalid JSON
         """
-        yield self._init_sitemap()
-        url = self.sitemap['monitor'] + '/list-sensors/all'
+        url = (yield self.get_sitemap())['monitor'] + '/list-sensors/all'
 
         if isinstance(filters, basestring):
             filters = [filters]
@@ -1516,9 +1540,8 @@ class KATPortalClient(object):
             'chunk_size': SAMPLE_HISTORY_CHUNK_SIZE,
             'limit': MAX_SAMPLES_PER_HISTORY_QUERY
         }
-        yield self._init_sitemap()
         url = url_concat(
-            self.sitemap['historic_sensor_values'] + '/samples', params)
+            (yield self.get_sitemap())['historic_sensor_values'] + '/samples', params)
         self._logger.debug("Sensor history request: %s", url)
         response = yield self._http_client.fetch(url)
         data = json.loads(response.body)
@@ -1647,8 +1670,7 @@ class KATPortalClient(object):
             {..}]
 
         """
-        yield self._init_sitemap()
-        url = self.sitemap['userlogs'] + '/tags'
+        url = (yield self.get_sitemap())['userlogs'] + '/tags'
         response = yield self._http_client.fetch(url)
         raise tornado.gen.Return(json.loads(response.body))
 
@@ -1744,8 +1766,7 @@ class KATPortalClient(object):
                 'end_time': '2017-02-07 23:59:59'
              }, {..}]
         """
-        yield self._init_sitemap()
-        url = self.sitemap['userlogs'] + '/query?'
+        url = (yield self.get_sitemap())['userlogs'] + '/query?'
         if start_time is None:
             start_time = time.strftime('%Y-%m-%d 00:00:00')
         if end_time is None:
@@ -1806,8 +1827,7 @@ class KATPortalClient(object):
                 'end_time': '2017-02-07 23:59:59'
              }
         """
-        yield self._init_sitemap()
-        url = self.sitemap['userlogs']
+        url = (yield self.get_sitemap())['userlogs']
         new_userlog = {
             'user': self._current_user_id,
             'content': content
@@ -1871,8 +1891,7 @@ class KATPortalClient(object):
                 raise
         else:
             userlog['tag_ids'] = tag_ids
-        yield self._init_sitemap()
-        url = '{}/{}'.format(self.sitemap['userlogs'], userlog['id'])
+        url = '{}/{}'.format((yield self.get_sitemap())['userlogs'], userlog['id'])
         response = yield self.authorized_fetch(
             url=url, auth_token=self._session_id,
             method='POST', body=json.dumps(userlog))
@@ -1921,12 +1940,11 @@ class KATPortalClient(object):
         """
         if sensor is None or len(sensor.strip()) == 0:
             sensor = r'%20'  # use single space for component-only lookup
-        yield self._init_sitemap()
         url = (
             "{base_url}/{sub_nr}/sensor-lookup/{component}/{sensor}/{katcp_format}"
             .format(
-                base_url=self.sitemap['subarray'],
-                sub_nr=self.sub_nr,
+                base_url=(yield self.get_sitemap())['subarray'],
+                sub_nr=(yield self.get_sub_nr()),
                 component=component,
                 sensor=sensor,
                 katcp_format=1 if return_katcp_name else 0))

--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -315,7 +315,7 @@ class KATPortalClient(object):
                 http_client.close()
         else:
             result['websocket'] = url
-        return result
+        raise tornado.gen.Return(result)
 
     @tornado.gen.coroutine
     def _init_sitemap(self):

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -31,6 +31,7 @@ from katportalclient import (
 
 LOGGER_NAME = 'test_portalclient'
 NEW_WEBSOCKET_DELAY = 0.05
+SITEMAP_URL = 'http://dummy.for.sitemap/api/client/3'
 
 
 # Example JSON text for sensor request responses
@@ -185,31 +186,13 @@ class TestKATPortalClient(WebSocketBaseTestCase):
 
         self.websocket_url = 'ws://localhost:%d/test' % self.get_http_port()
 
-        @gen.coroutine
-        def mock_fetch(url):
-            sitemap = {'client':
-                       {'websocket': self.websocket_url,
-                        'historic_sensor_values': r"http://0.0.0.0/history",
-                        'schedule_blocks': r"http://0.0.0.0/sb",
-                        'capture_blocks': r"http://0.0.0.0/cb",
-                        'subarray_sensor_values': r"http://0.0.0.0/sensor-list",
-                        'target_descriptions': r"http://0.0.0.0/sources",
-                        'sub_nr': '3',
-                        'authorization': r"http://0.0.0.0/katauth",
-                        'userlogs': r"http://0.0.0.0/katcontrol/userlogs",
-                        'subarray': r"http:/0.0.0.0/katcontrol/subarray",
-                        'monitor': r"http:/0.0.0.0/katmonitor",
-                        }
-                       }
-            body_buffer = buffer_bytes_io(json.dumps(sitemap))
-            return HTTPResponse(HTTPRequest(url), 200, buffer=body_buffer)
-
-        # Mock the synchronous HTTP client, with our sitemap
+        # Mock the asynchronous HTTP client
         http_async_client_patcher = mock.patch(
             'tornado.httpclient.AsyncHTTPClient')
         self.addCleanup(http_async_client_patcher.stop)
         self.mock_http_async_client = http_async_client_patcher.start()
-        self.mock_http_async_client().fetch.side_effect = mock_fetch
+        # Set up a fetcher that just knows about the sitemap
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher('')
 
         def on_update_callback(msg, self):
             self.logger.info("Client got update message: '{}'".format(msg))
@@ -218,7 +201,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         self.on_update_callback_call_count = 0
         on_msg_callback = partial(on_update_callback, self=self)
         self._portal_client = KATPortalClient(
-            'http://dummy.for.sitemap/api/client/3',
+            SITEMAP_URL,
             on_msg_callback,
             io_loop=self.io_loop)
 
@@ -499,7 +482,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         schedule_block_base_url = self._portal_client.sitemap[
             'schedule_blocks']
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=r"""
                 {"result":
                     "[{\"id_code\":\"20160908-0004\",\"owner\":\"CAM\",\"type\":\"OBSERVATION\",\"sub_nr\":1},
@@ -526,7 +509,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         schedule_block_base_url = self._portal_client.sitemap[
             'schedule_blocks']
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=r"""
                 {"result":
                     "[{\"id_code\":\"20160908-0004\",\"owner\":\"CAM\",\"type\":\"OBSERVATION\",\"sub_nr\":1},
@@ -549,7 +532,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'schedule_blocks']
         schedule_block_id = "20160908-0005"
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=r"""
                 {"result":
                     {"id_code":"20160908-0005",
@@ -594,7 +577,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'capture_blocks']
         capture_block_id = "1556092846"
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=r"""
                 {"result":["20190424-0009", "20190424-0010"]}""",
             invalid_response=r"""{"result":null}""",
@@ -613,7 +596,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'capture_blocks']
         capture_block_id = "123456"
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=r"""{"result":[]}""",
             invalid_response=r"""{"result":null}""",
             starts_with=capture_block_base_url)
@@ -629,7 +612,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'historic_sensor_values']
         sensor_name_filter = 'anc_weather_wind_speed'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}]'.format(
                 sensor_json['anc_weather_wind_speed']),
             invalid_response='[]',
@@ -648,7 +631,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'historic_sensor_values']
         sensor_name_filter = 'anc_w.*_device_status'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}, {}]'.format(sensor_json['anc_wind_device_status'],
                                              sensor_json['anc_weather_device_status']),
             invalid_response='[]',
@@ -669,7 +652,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         sensor_name_filters = [
             'anc_weather_wind_speed', 'anc_weather_wind_speed']
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}]'.format(
                 sensor_json['anc_weather_wind_speed']),
             invalid_response='[]',
@@ -687,7 +670,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         history_base_url = self._portal_client.sitemap[
             'historic_sensor_values']
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[]',
             invalid_response='[{}]'.format(
                 sensor_json['anc_weather_wind_speed']),
@@ -703,7 +686,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         history_base_url = self._portal_client.sitemap[
             'historic_sensor_values']
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response=sensor_json['regex_error'],
             invalid_response='[]',
             starts_with=history_base_url)
@@ -718,7 +701,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'historic_sensor_values']
         sensor_name = 'anc_weather_wind_speed'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}]'.format(
                 sensor_json['anc_weather_wind_speed']),
             invalid_response='[]',
@@ -751,7 +734,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'historic_sensor_values']
         sensor_name_filter = 'anc_gust_wind_speed'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}, {}]'.format(sensor_json['anc_gust_wind_speed2'],
                                              sensor_json['anc_gust_wind_speed']),
             invalid_response="[]",
@@ -768,7 +751,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             'historic_sensor_values']
         sensor_name_filter = 'anc_w.*_device_status'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='[{}, {}]'.format(sensor_json['anc_wind_device_status'],
                                              sensor_json['anc_weather_device_status']),
             invalid_response="[]",
@@ -782,7 +765,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
     def test_sensor_value_invalid_results(self):
         """test that we handle the monitor server returning an invalid string"""
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response('')
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher('')
         with self.assertRaises(InvalidResponseError):
             yield self._portal_client.sensor_value("INVALID_SENSOR")
 
@@ -790,7 +773,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
     def test_sensor_value_no_results(self):
         """Test that we handle no matches"""
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response('[]')
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher('[]')
         with self.assertRaises(SensorNotFoundError):
             yield self._portal_client.sensor_value("INVALID_SENSOR")
 
@@ -807,13 +790,13 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                         '"value_ts":111.111,"time":222.222}]')
 
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         result = yield self._portal_client.sensor_value("anc_tfr_m018_l_band_offset")
         expected_result = SensorSample(timestamp=1531302437, value=43680.0,
                                        status='nominal')
         assert result == expected_result
 
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         result = yield self._portal_client.sensor_value("anc_tfr_m018_l_band_offset",
                                                         include_value_ts=True)
         expected_result = SensorSampleValueTs(timestamp=1531302437,
@@ -834,7 +817,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                         '"value_ts":111.111,"time":222.222}]')
 
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         with self.assertRaises(SensorNotFoundError):
             yield self._portal_client.sensor_value("anc_tfr_m018_l_band_offset_average")
 
@@ -846,12 +829,12 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                         '"value_ts":111.111,"time":222.222}]')
 
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         expected_result = SensorSample(timestamp=222.222, value=43680.0, status='nominal')
         res = yield self._portal_client.sensor_value("anc_tfr_m018_l_band_offset_average")
         assert res == expected_result
 
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         expected_result = SensorSampleValueTs(timestamp=222.222, value_timestamp=111.111,
                                               value=43680.0, status=u'nominal')
         res = yield self._portal_client.sensor_value("anc_tfr_m018_l_band_offset_average",
@@ -862,7 +845,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
     def test_sensor_values_invalid_results(self):
         """test that we handle the monitor server returning an invalid string"""
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response('')
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher('')
         with self.assertRaises(InvalidResponseError):
             yield self._portal_client.sensor_values("INVALID_FILTER")
 
@@ -870,7 +853,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
     def test_sensor_values_no_results(self):
         """Test that we handle no matches"""
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response('[]')
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher('[]')
         with self.assertRaises(SensorNotFoundError):
             yield self._portal_client.sensor_values("INVALID_FILTER")
 
@@ -887,7 +870,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                         '"value_ts":111.111,"time":222.222}]')
 
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         result = yield self._portal_client.sensor_values("ARBITRARY_FILTER")
         expected_result = {
             "anc_tfr_m018_l_band_offset": SensorSample(timestamp=1531302437,
@@ -898,7 +881,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                                               status='nominal')}
         assert result == expected_result
 
-        self.mock_http_async_client().fetch.side_effect = fake_http_response(mon_response)
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(mon_response)
         result = yield self._portal_client.sensor_values("ARBITRARY_FILTER",
                                                          include_value_ts=True)
         expected_result = {
@@ -926,7 +909,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                           '"value_ts":111.111,"time":221.222}]')
 
         yield self._portal_client._init_sitemap()   # Before we overwrite the mock fetch
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetchers(
             valid_responses=[mon_response_0, mon_response_1],
             invalid_responses=['1error', '2error'],
             containses=["sample_0", "sample_1"]
@@ -953,7 +936,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         publish_messages = [sensor_history_pub_messages_json['init']]
         publish_messages.extend(sensor_history_pub_messages_json[sensor_name])
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"success"}',
             invalid_response='error',
             starts_with=history_base_url,
@@ -1000,7 +983,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         publish_messages = [sensor_history_pub_messages_json['init']]
         publish_messages.extend(sensor_history_pub_messages_json[sensor_name])
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"success"}',
             invalid_response='error',
             starts_with=history_base_url,
@@ -1032,7 +1015,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         publish_messages.append(
             sensor_history_pub_messages_json[sensor_name][-1])
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"success"}',
             invalid_response='error',
             starts_with=history_base_url,
@@ -1054,7 +1037,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         publish_messages = [sensor_history_pub_messages_json['init']]
         publish_messages.extend(sensor_history_pub_messages_json[sensor_name])
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"success"}',
             invalid_response='error',
             starts_with=history_base_url,
@@ -1086,7 +1069,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         #  - 1st call gives sensor list
         #  - 2nd call provides the sample history for sensor 0
         #  - 3rd call provides the sample history for sensor 1
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetchers(
             valid_responses=[
                 '[{}, {}]'.format(sensor_json[sensor_names[0]],
                                   sensor_json[sensor_names[1]]),
@@ -1143,7 +1126,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         # complicated way to define the behaviour for the 2 expected HTTP requests
         #  - 1st call provides the sample history for sensor 0
         #  - 2nd call provides the sample history for sensor 1
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetchers(
             valid_responses=[
                 '{"result":"success"}',
                 '{"result":"success"}'],
@@ -1191,7 +1174,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         sb_id_code_2 = "20160908-0006"
         sb_id_code_3 = "20160908-0007"
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetchers(
             valid_responses=[
                 r"""
                 {"result":
@@ -1330,7 +1313,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         """Test userlogs tags listing"""
         base_url = self._portal_client.sitemap['userlogs'] + '/tags'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetchers(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetchers(
             valid_responses=[r"""[{
                 "activated": "True",
                 "slug": "",
@@ -1552,7 +1535,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         sensor_name_filter = 'device_status'
         expected_sensor_name = 'cbf_3_device_status'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"cbf_3_device_status"}',
             invalid_response=['error'],
             starts_with=lookup_base_url,
@@ -1569,7 +1552,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         sensor_name_filter = 'device-status'
         expected_sensor_name = 'cbf_3.device-status'
 
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"result":"cbf_3.device-status"}',
             invalid_response=['error'],
             starts_with=lookup_base_url,
@@ -1584,7 +1567,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
         lookup_base_url = (self._portal_client.sitemap['subarray'] +
                            '/3/sensor-lookup/anc/device_status/0')
         sensor_name_filter = 'device_status'
-        self.mock_http_async_client().fetch.side_effect = mock_async_fetcher(
+        self.mock_http_async_client().fetch.side_effect = self.mock_async_fetcher(
             valid_response='{"error":"SensorLookupError: Could not lookup the sensor '
                            'on component. Could not determine component."}',
             invalid_response='[]',
@@ -1595,89 +1578,99 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                 'anc', sensor_name_filter, False)
 
 
-def mock_async_fetchers(valid_responses, invalid_responses, starts_withs=None,
-                        ends_withs=None, containses=None, publish_raw_messageses=None,
-                        client_stateses=None):
-    """Allows definition of multiple HTTP async fetchers."""
-    num_calls = len(valid_responses)
-    if starts_withs is None or isinstance(starts_withs, basestring):
-        starts_withs = [starts_withs] * num_calls
-    if ends_withs is None or isinstance(ends_withs, basestring):
-        ends_withs = [ends_withs] * num_calls
-    if containses is None or isinstance(containses, basestring):
-        containses = [containses] * num_calls
-    if publish_raw_messageses is None:
-        publish_raw_messageses = [None] * num_calls
-    if client_stateses is None:
-        client_stateses = [None] * num_calls
-    assert(len(invalid_responses) == num_calls)
-    assert(len(starts_withs) == num_calls)
-    assert(len(ends_withs) == num_calls)
-    assert(len(containses) == num_calls)
-    assert(len(publish_raw_messageses) == num_calls)
-    assert(len(client_stateses) == num_calls)
+    def mock_async_fetchers(self, valid_responses, invalid_responses, starts_withs=None,
+                            ends_withs=None, containses=None, publish_raw_messageses=None,
+                            client_stateses=None):
+        """Allows definition of multiple HTTP async fetchers."""
+        num_calls = len(valid_responses)
+        if starts_withs is None or isinstance(starts_withs, basestring):
+            starts_withs = [starts_withs] * num_calls
+        if ends_withs is None or isinstance(ends_withs, basestring):
+            ends_withs = [ends_withs] * num_calls
+        if containses is None or isinstance(containses, basestring):
+            containses = [containses] * num_calls
+        if publish_raw_messageses is None:
+            publish_raw_messageses = [None] * num_calls
+        if client_stateses is None:
+            client_stateses = [None] * num_calls
+        assert(len(invalid_responses) == num_calls)
+        assert(len(starts_withs) == num_calls)
+        assert(len(ends_withs) == num_calls)
+        assert(len(containses) == num_calls)
+        assert(len(publish_raw_messageses) == num_calls)
+        assert(len(client_stateses) == num_calls)
 
-    mock_fetches = [mock_async_fetcher(v, i, s, e, c, p, cs)
-                    for v, i, s, e, c, p, cs in zip(
-                        valid_responses, invalid_responses,
-                        starts_withs, ends_withs, containses,
-                        publish_raw_messageses, client_stateses)]
-    # flip order so that poping effectively goes from first to last input
-    mock_fetches.reverse()
+        mock_fetches = [self.mock_async_fetcher(v, i, s, e, c, p, cs)
+                        for v, i, s, e, c, p, cs in zip(
+                            valid_responses, invalid_responses,
+                            starts_withs, ends_withs, containses,
+                            publish_raw_messageses, client_stateses)]
+        # flip order so that poping effectively goes from first to last input
+        mock_fetches.reverse()
 
-    def mock_fetch(url):
-        single_fetch = mock_fetches.pop()
-        return single_fetch(url)
+        def mock_fetch(url):
+            single_fetch = mock_fetches.pop()
+            return single_fetch(url)
 
-    return mock_fetch
-
-
-def mock_async_fetcher(valid_response, invalid_response, starts_with=None,
-                       ends_with=None, contains=None, publish_raw_messages=None,
-                       client_states=None):
-    """Returns a mock HTTP async fetch function, depending on the conditions."""
-
-    def mock_fetch(url, method="GET", body=None):
-        start_ok = starts_with is None or url.startswith(starts_with)
-        end_ok = ends_with is None or url.endswith(ends_with)
-        contains_ok = contains is None or contains in url
-
-        if start_ok and end_ok and contains_ok:
-            body_buffer = buffer_bytes_io(valid_response)
-        else:
-            body_buffer = buffer_bytes_io(invalid_response)
-
-        # optionally send raw message from test websocket server
-        if publish_raw_messages and test_websocket:
-            for raw_message in publish_raw_messages:
-                if isinstance(client_states, dict):
-                    # we need to rewrite the namespace, since the client
-                    # generates a random one per request at runtime.
-                    # We have to find the state dict that contains the sensor
-                    # name (in 'contains') to figure out which namespace
-                    # is being used for this sensor (yes, it is hacky)
-                    namespace = None
-                    for key, state in client_states.items():
-                        if contains == state['sensor']:
-                            namespace = key
-                    raw_message = raw_message.replace(
-                        'test_namespace', namespace)
-                test_websocket.write_message(raw_message)
-
-        result = HTTPResponse(HTTPRequest(url), 200, buffer=body_buffer)
-        future = concurrent.Future()
-        future.set_result(result)
-        return future
-
-    return mock_fetch
+        return mock_fetch
 
 
-def fake_http_response(response_string):
-    """Used as a mock side effect response for AsyncHTTPClient.fetch"""
-    result = HTTPResponse(HTTPRequest(''), 200, buffer=buffer_bytes_io(response_string))
-    future = concurrent.Future()
-    future.set_result(result)
-    return [future]
+    def mock_async_fetcher(self, valid_response, invalid_response=None, starts_with=None,
+                           ends_with=None, contains=None, publish_raw_messages=None,
+                           client_states=None):
+        """Returns a mock HTTP async fetch function, depending on the conditions."""
+
+        def mock_fetch(url, method="GET", body=None):
+            if url == SITEMAP_URL:
+                sitemap = {'client':
+                           {'websocket': self.websocket_url,
+                            'historic_sensor_values': r"http://0.0.0.0/history",
+                            'schedule_blocks': r"http://0.0.0.0/sb",
+                            'capture_blocks': r"http://0.0.0.0/cb",
+                            'subarray_sensor_values': r"http://0.0.0.0/sensor-list",
+                            'target_descriptions': r"http://0.0.0.0/sources",
+                            'sub_nr': '3',
+                            'authorization': r"http://0.0.0.0/katauth",
+                            'userlogs': r"http://0.0.0.0/katcontrol/userlogs",
+                            'subarray': r"http:/0.0.0.0/katcontrol/subarray",
+                            'monitor': r"http:/0.0.0.0/katmonitor",
+                            }
+                           }
+                response = json.dumps(sitemap)
+            else:
+                start_ok = starts_with is None or url.startswith(starts_with)
+                end_ok = ends_with is None or url.endswith(ends_with)
+                contains_ok = contains is None or contains in url
+
+                if (start_ok and end_ok and contains_ok) or invalid_response is None:
+                    response = valid_response
+                else:
+                    response = invalid_response
+
+                # optionally send raw message from test websocket server
+                if publish_raw_messages and test_websocket:
+                    for raw_message in publish_raw_messages:
+                        if isinstance(client_states, dict):
+                            # we need to rewrite the namespace, since the client
+                            # generates a random one per request at runtime.
+                            # We have to find the state dict that contains the sensor
+                            # name (in 'contains') to figure out which namespace
+                            # is being used for this sensor (yes, it is hacky)
+                            namespace = None
+                            for key, state in client_states.items():
+                                if contains == state['sensor']:
+                                    namespace = key
+                            raw_message = raw_message.replace(
+                                'test_namespace', namespace)
+                        test_websocket.write_message(raw_message)
+
+            body_buffer = buffer_bytes_io(response)
+            result = HTTPResponse(HTTPRequest(url), 200, buffer=body_buffer)
+            future = concurrent.Future()
+            future.set_result(result)
+            return future
+
+        return mock_fetch
 
 
 def buffer_bytes_io(message):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     use_katversion=True,
     install_requires=[
         "future",
-        "futures; python_version<'3'"
+        "futures; python_version<'3'",
         "tornado>=4.0",
         "omnijson>=0.1.2",
         "ujson>=1.33, <2.0",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     use_katversion=True,
     install_requires=[
         "future",
+        "futures; python_version<'3'"
         "tornado>=4.0",
         "omnijson>=0.1.2",
         "ujson>=1.33, <2.0",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     use_katversion=True,
     install_requires=[
         "future",
-        "tornado>=4.0, <5.0",
+        "tornado>=4.0",
         "omnijson>=0.1.2",
         "ujson>=1.33, <2.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
     install_requires=[
         "future",
         "futures; python_version<'3'",
-        "tornado>=4.0",
+        "tornado>=4.0, <7.0; python_version>='3'",
+        "tornado>=4.0, <5.0; python_version<'3'",
         "omnijson>=0.1.2",
         "ujson>=1.33, <2.0",
     ],


### PR DESCRIPTION
This (99%) fixes CB-2358, which on Tornado 6 (and maybe 5? untested) caused errors. Fetching the sitemap is now done with coroutines where possible, and with a helper thread if the user directly accesses the property before the sitemap has been fetched.

Also removed the `tornado<5` version pin in setup.py. That may be a reason not to merge.