### PR TITLE
Fix quoting of sensor filters in URLs

### DIFF
--- a/katportalclient/client.py
+++ b/katportalclient/client.py
@@ -1194,7 +1194,8 @@ class KATPortalClient(object):
             filters = [filters]
         results = set()
         for filt in filters:
-            response = yield self._http_client.fetch("{}?sensors={}".format(url, filt))
+            query_url = url_concat(url, {"sensors": filt})
+            response = yield self._http_client.fetch(query_url)
             new_sensors = self._extract_sensors_details(response.body)
             # only add sensors once, to ensure a unique list
             for sensor in new_sensors:
@@ -1393,8 +1394,8 @@ class KATPortalClient(object):
         results_to_return = {}
 
         for filt in filters:
-            response = yield self._http_client.fetch(
-                "{}?reading_only=1&name_filter={}$".format(url, filt))
+            query_url = url_concat(url, {"reading_only": "1", "name_filter": filt})
+            response = yield self._http_client.fetch(query_url)
             try:
                 results = json.loads(response.body)
             except json.JSONError:

--- a/katportalclient/test/test_client.py
+++ b/katportalclient/test/test_client.py
@@ -8,6 +8,7 @@ standard_library.install_aliases()  # noqa: E402
 import logging
 import io
 import time
+from urllib.parse import quote_plus
 
 import mock
 import omnijson as json
@@ -745,7 +746,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
                                                   sensor_json['anc_weather_device_status']),
             invalid_response='[]',
             starts_with=history_base_url,
-            contains=sensor_name_filter)
+            contains=quote_plus(sensor_name_filter))
 
         sensors = yield self._portal_client.sensor_names(sensor_name_filter)
 
@@ -1138,7 +1139,7 @@ class TestKATPortalClient(WebSocketBaseTestCase):
             invalid_responses=['1error', '2error', '3error'],
             starts_withs=history_base_url,
             containses=[
-                sensor_name_filter,
+                quote_plus(sensor_name_filter),
                 sensor_names[0],
                 sensor_names[1]])
 


### PR DESCRIPTION
URLs were being constructed by just dumping user input into query
parameters without concern for quoting. When the parameter is a regular
expression this can have consequences, such as +'s turning into spaces.

I haven't fixed this everywhere, but I've fixed it in two places where
regular expressions were expected to be used. It should ideally be used
everywhere that URL query parameters are constructed though.