### PR TITLE
Fix encoding problem reading changelog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@
 
 from os import path
 from setuptools import setup, find_packages
+from sys import version_info
 
+PYTHON2 = (2,) <= version_info < (3,)
 
 this_directory = path.abspath(path.dirname(__file__))
 
@@ -14,7 +16,8 @@ long_description = ""
 for name, filename in files.items():
     if name != 'Readme':
         long_description += "# {}\n".format(name)
-    with open(path.join(this_directory, filename), encoding='utf8') as _f:
+    open_kwargs = {'encoding': 'utf8'} if not PYTHON2 else {}
+    with open(path.join(this_directory, filename), **open_kwargs) as _f:
         file_contents = _f.read()
     long_description += file_contents + "\n\n"
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = ""
 for name, filename in files.items():
     if name != 'Readme':
         long_description += "# {}\n".format(name)
-    with open(path.join(this_directory, filename)) as _f:
+    with open(path.join(this_directory, filename), encoding='utf8') as _f:
         file_contents = _f.read()
     long_description += file_contents + "\n\n"
 


### PR DESCRIPTION
The Unicode `…` characters cause a problem on some environments when pip installing.  Probably locale specific, since the default encoding used by `open` depends on the locale.  Now explicitly set it to UTF-8.

```
Processing /path/to/katportalclient
  Running setup.py (path:/tmp/pip-dqxy93lt-build/setup.py) egg_info for package from file:///path/to/katportalclient
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-dqxy93lt-build/setup.py", line 18, in <module>
        file_contents = _f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 5094: ordinal not in range(128)
```